### PR TITLE
fix: disable rulers when viewing shortcuts

### DIFF
--- a/dired.py
+++ b/dired.py
@@ -1029,6 +1029,7 @@ class DiredHelpCommand(TextCommand):
         view.settings().set('color_scheme','Packages/FileBrowser/dired.hidden-tmTheme')
         view.settings().set('syntax','Packages/FileBrowser/dired-help.hidden-tmLanguage')
         view.settings().set('line_numbers',False)
+        view.settings().set('rulers',[])
         view.run_command('dired_show_help')
         sublime.active_window().focus_view(view)
 


### PR DESCRIPTION
Pending https://github.com/aziz/SublimeFileBrowser/pull/84.
